### PR TITLE
fix: allow no children to the LdapAuthFrontendPage

### DIFF
--- a/packages/ldap-auth/src/components/LoginPage/LoginPage.tsx
+++ b/packages/ldap-auth/src/components/LoginPage/LoginPage.tsx
@@ -32,7 +32,7 @@ import { LoginForm } from './Form';
  */
 export type LdapSignInPageProps = SignInPageProps & {
     provider: string;
-    children?: React.ReactElement;
+    children?: React.ReactElement | null;
     options?: {
         helperTextPassword?: string;
         helperTextUsername?: string;


### PR DESCRIPTION
## 🚨 Proposed changes

Fix type in Frontend plugin, now it is possible to use LdapAuthFrontendPage without children.

close #100 

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
