### PR TITLE
feat: the children parameter type of LdapSignInPageProps type is now …

### DIFF
--- a/packages/ldap-auth/src/components/LoginPage/LoginPage.tsx
+++ b/packages/ldap-auth/src/components/LoginPage/LoginPage.tsx
@@ -32,7 +32,7 @@ import { LoginForm } from './Form';
  */
 export type LdapSignInPageProps = SignInPageProps & {
     provider: string;
-    children?: React.ReactElement | null;
+    children?: React.ReactNode | null;
     options?: {
         helperTextPassword?: string;
         helperTextUsername?: string;


### PR DESCRIPTION
I switch the children element type of form into `ReactNode`,  this is a more permissive type with respect to the ReactElement

BREAKING CHANGE: the children parameter type of LdapSignInPageProps type is now a ReactNode

close #184 

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
