### PR TITLE
Allow the usage of a custom resultRenderer

### DIFF
--- a/packages/ldap-auth-backend/src/auth.ts
+++ b/packages/ldap-auth-backend/src/auth.ts
@@ -2,6 +2,7 @@ import type {
     BackstageSignInResult,
     BackstageIdentityResponse,
     LDAPUser,
+    AuthenticationResult
 } from './types';
 
 import { ProfileInfo } from '@backstage/core-plugin-api';
@@ -27,7 +28,7 @@ export function prepareBackstageIdentityResponse(
     };
 }
 
-export const defaultSigninResolver: SignInResolver<LDAPUser> = async (
+export const defaultSigninResolver: SignInResolver<AuthenticationResult> = async (
     { result },
     ctx: AuthResolverContext
 ): Promise<BackstageSignInResult> => {

--- a/packages/ldap-auth-backend/src/ldap.ts
+++ b/packages/ldap-auth-backend/src/ldap.ts
@@ -1,4 +1,4 @@
-import type { LDAPUser } from './types';
+import type { LDAPUser, AuthenticationResult } from './types';
 
 import ldap from 'ldapjs';
 import { dn } from 'ldap-escape';
@@ -95,4 +95,8 @@ export async function defaultLDAPAuthentication(
         );
         throw e;
     }
+}
+
+export async function defaultResultRenderer(result: AuthenticationResult, parsedToken: any) {
+  return { uid: result.uid as string };
 }

--- a/packages/ldap-auth-backend/src/types.ts
+++ b/packages/ldap-auth-backend/src/types.ts
@@ -97,7 +97,12 @@ import type { TokenValidator } from './jwt';
 import type { AuthResolverContext } from '@backstage/plugin-auth-backend';
 import type { AuthenticationOptions } from 'ldap-authentication';
 import { defaultAuthHandler, defaultSigninResolver } from './auth';
-import { defaultCheckUserExists, defaultLDAPAuthentication } from './ldap';
+import { defaultCheckUserExists, defaultLDAPAuthentication, defaultResultRenderer } from './ldap';
+
+export type AuthenticationResult = {
+    uid: string,
+    [key: string]: any
+};
 
 export type CookiesOptions = {
     field: string;
@@ -121,6 +126,7 @@ export type ProviderCreateOptions = {
     resolvers?: {
         checkUserExists?: typeof defaultCheckUserExists;
         ldapAuthentication?: typeof defaultLDAPAuthentication;
+        resultRenderer?: typeof defaultResultRenderer;
     };
     // Custom validator function for the JWT token if needed
     tokenValidator?: TokenValidator;
@@ -133,6 +139,7 @@ export type ProviderConstructor = {
     signInResolver: typeof defaultSigninResolver;
     checkUserExists: typeof defaultCheckUserExists;
     ldapAuthentication: typeof defaultLDAPAuthentication;
+    resultRenderer: typeof defaultResultRenderer;
     resolverContext: AuthResolverContext;
     tokenValidator?: TokenValidator;
 };


### PR DESCRIPTION
First of all let me start by thanking you for the great ldap-auth Backstage plugin!

At my company we have microservices to orchestrate infrastructure. There is also a ms-auth microservice (with a LDAP backend) where users can get a JWT token by requesting an API endpoint with their LDAP username and password. With this JWT token they can access the infra microservices. In Backstage we created a plugin where a user can view the infrastructure that he owns. We use authMiddleware (derived from [authenticate-api-requests.md](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md)). So when a call is made to the Backstage API proxy `/api/proxy/infra` (or deeper path), the authMiddleware will decode the Backstage JWT token from the identity and get the infra JWT token from it. Then it sets that infra JWT token as Authorization header in the request to the actual infra microservice.

We put the following code inside `packages/backend/src/plugins/auth.ts`:

    import { ldap, JWTTokenValidator } from '@immobiliarelabs/backstage-plugin-ldap-auth-backend';
    import Keyv from 'keyv';
    import fetch from 'node-fetch';

    export default async function createPlugin(
      env: PluginEnvironment,
    ): Promise<Router> {
      return await createRouter({
        logger: env.logger,
        config: env.config,
        database: env.database,
        discovery: env.discovery,
        tokenManager: env.tokenManager,
        providerFactories: {
          ...defaultAuthProviderFactories,

          ldap: ldap.create({
            tokenValidator: new JWTTokenValidator(new Keyv()),
            resolvers: {
              // Is called after login form
              async ldapAuthentication(username, password, ldapOptions, authFunction) {
                env.logger.debug('Executing INFRA LDAP resolvers.ldapAuthentication')

                const response = await fetch(env.config.getString('backend.infra.msAuthUrl'), {
                  method: 'POST',
                  headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
                  body: JSON.stringify({ username: username, password: password })
                });
                if (response.status != 200) {
                  throw new Error(`Failed to authenticate username ${username} with ms-auth ` +
                    `[${response.status}]: ${await response.text()}`
                  );
                }

                const infraContext = await response.json();

                const authenticationResult = {
                  uid: infraContext.user.username,
                  infra_ms_auth_token: infraContext.jwt.replace('Bearer ', '') as string
                }

                return authenticationResult
              },
              // Is called by /api/auth/ldap/refresh
              async checkUserExists(ldapAuthOptions, searchFunction): Promise<boolean> {
                env.logger.debug('Executing INFRA LDAP resolvers.checkUserExists')

                // In the default checkUserExists function the user is looked up by username in the catalog.
                // Only the username is available here, always return true. The resultRenderer will throw an error
                // if the infra ms-auth token of the user can't be refreshed. That is a similar check if the user exists
                // because the token used for authorization could be revoked.

                return true;
              },
              async resultRenderer(result, parsedToken) {
                env.logger.debug('Executing INFRA LDAP resolvers.resultRenderer')

                if (parsedToken) {
                  env.logger.debug('Extending expiration time of INFRA ms-auth token')

                  // Extend expiration time of INFRA ms-auth token
                  const response = await fetch(env.config.getString('backend.infra.msAuthUrl') + '/jwt', {
                    method: 'PUT',
                    headers: {
                      'Content-Type': 'application/json',
                      Accept: 'application/json',
                      Authorization: parsedToken['infra_ms_auth_token']
                    },
                  });
                  if (response.status != 204) {
                    throw new Error(`Failed to extend INFRA JWT token expiration time for username ${result.uid} with ` +
                      `ms-auth [${response.status}]: ${await response.text()}`);
                  }

                  result['infra_ms_auth_token'] = parsedToken['infra_ms_auth_token']
                }

                return result;
              }
            },
            // Is called after one of the resolvers above (input only has uid property)
            // This configured authHandler is called (which doesn't require a catalog user) instead of defaultAuthHAndler
            // that calls ctx.findCatalogUser and thus requires a catalog user
            authHandler: async function (input, context) {
              env.logger.debug('Executing INFRA LDAP authHandler')

              return { profile: { email: '', displayName: input.uid, picture: '' } }
            },
            signIn: {
              // Is called after the authHandler above
              resolver(info, ctx) {
                env.logger.debug('Executing INFRA LDAP signIn.resolver')

                const infraMsAuthParsedToken = JSON.parse(
                  Buffer.from(info.result.infra_ms_auth_token.split('.')[1], 'base64').toString()
                )

                info.profile.email = infraMsAuthParsedToken.email
                info.profile.displayName = infraMsAuthParsedToken.name

                // Set profile picture
                if (info.profile.email) {
                  info.profile.picture = 'https://gravatar.com/avatar/' +
                    createHash('md5').update(info.profile.email).digest('hex') + '?s=600'
                }

                const userRef = stringifyEntityRef({
                  kind: 'User',
                  name: info.result.uid as string,
                  namespace: DEFAULT_NAMESPACE
                });

                return ctx.issueToken({
                  claims: {
                    sub: userRef, // The user's own identity
                    ent: [userRef], // A list of identities that the user claims ownership through
                    // Store the infra ms auth token inside the Backstage JWT token
                    infra_ms_auth_token: info.result.infra_ms_auth_token
                  },
                });
              }
            }
          })
        },
      });
    }

In the code above we add an extra key `infra_ms_auth_token` to the result. This way it will be available in the signIn resolver function so that we can extract profile information from it, but also set a `infra_ms_auth_token` claim in the `ctx.issueToken` function.

This PR makes it possible to add additional keys to the result besides the `uid` key. With the Node.js package [patch-package](https://www.npmjs.com/package/patch-package) I made changes to make the code above work. I then cloned this repository and made the changes in this PR manually, but I don't know how to test it.