### PR TITLE
fix: Improve error message for no user details returned

### DIFF
--- a/packages/ldap-auth-backend/src/errors.ts
+++ b/packages/ldap-auth-backend/src/errors.ts
@@ -8,3 +8,6 @@ export const AUTH_MISSING_CREDENTIALS =
 
 export const AUTH_USER_NOT_FOUND =
     'AUTH_USER_NOT_FOUND: Credential invalid or user doesnt exists';
+
+export const AUTH_USER_DATA_ERROR =
+    'AUTH_USER_DATA_ERROR: The user returned does not contain the configured usernameAttribute';

--- a/packages/ldap-auth-backend/src/ldap.test.ts
+++ b/packages/ldap-auth-backend/src/ldap.test.ts
@@ -1,5 +1,5 @@
 import { defaultCheckUserExists, defaultLDAPAuthentication } from './ldap';
-import { AUTH_USER_NOT_FOUND } from './errors';
+import { AUTH_USER_DATA_ERROR } from './errors';
 import { AuthenticationOptions } from 'ldap-authentication';
 
 describe('LDAP authentication', () => {
@@ -35,7 +35,7 @@ describe('LDAP authentication', () => {
         );
 
         expect(authFunc).toBeCalled();
-        expect(out).rejects.toEqual(new Error(AUTH_USER_NOT_FOUND));
+        expect(out).rejects.toEqual(new Error(AUTH_USER_DATA_ERROR));
     });
 });
 

--- a/packages/ldap-auth-backend/src/ldap.ts
+++ b/packages/ldap-auth-backend/src/ldap.ts
@@ -4,7 +4,11 @@ import ldap from 'ldapjs';
 import { dn } from 'ldap-escape';
 import { authenticate, AuthenticationOptions } from 'ldap-authentication';
 
-import { AUTH_USER_DATA_ERROR, AUTH_USER_NOT_FOUND, LDAP_CONNECT_FAIL } from './errors';
+import {
+    AUTH_USER_DATA_ERROR,
+    AUTH_USER_NOT_FOUND,
+    LDAP_CONNECT_FAIL,
+} from './errors';
 
 async function _verifyUserExistsNoAdmin(
     searchString: string,

--- a/packages/ldap-auth-backend/src/ldap.ts
+++ b/packages/ldap-auth-backend/src/ldap.ts
@@ -4,7 +4,7 @@ import ldap from 'ldapjs';
 import { dn } from 'ldap-escape';
 import { authenticate, AuthenticationOptions } from 'ldap-authentication';
 
-import { AUTH_USER_NOT_FOUND, LDAP_CONNECT_FAIL } from './errors';
+import { AUTH_USER_DATA_ERROR, AUTH_USER_NOT_FOUND, LDAP_CONNECT_FAIL } from './errors';
 
 async function _verifyUserExistsNoAdmin(
     searchString: string,
@@ -85,8 +85,11 @@ export async function defaultLDAPAuthentication(
 
     try {
         const user = await authFunction(authObj);
-        if (!user[usernameAttribute as string]) {
+        if (!user) {
             throw new Error(AUTH_USER_NOT_FOUND);
+        }
+        if (!user[usernameAttribute as string]) {
+            throw new Error(AUTH_USER_DATA_ERROR);
         }
         return { uid: user[usernameAttribute as string] };
     } catch (e) {


### PR DESCRIPTION
Closes: #700

## 🚨 Proposed changes

The code still throws an error in the same case as before, but now the error message is different if falsy value vs non existing entry.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
