### PR TITLE
feat: expose samesite cookie configuration

### DIFF
--- a/packages/ldap-auth-backend/README.md
+++ b/packages/ldap-auth-backend/README.md
@@ -112,6 +112,7 @@ auth:
                 cookies:
                     secure: false # https cookies or not
                     field: 'backstage-token' # default
+                    sameSite: false # default
 
                 ldapAuthenticationOptions:
                     userSearchBase: 'ou=users,dc=ns,dc=farm' # REQUIRED

--- a/packages/ldap-auth-backend/src/provider.ts
+++ b/packages/ldap-auth-backend/src/provider.ts
@@ -147,6 +147,7 @@ export class ProviderLdapAuthProvider implements AuthProviderRouteHandlers {
         maxAge,
         httpOnly: true,
         secure: this.cookies.secure,
+        sameSite: this.cookies.sameSite,
       });
 
       res.json(response);
@@ -178,6 +179,7 @@ export const ldap = {
       cnf.cookies = {
         field: cnf?.cookies?.field || COOKIE_FIELD_KEY,
         secure: cnf?.cookies?.secure || false,
+        sameSite: cnf?.cookies?.sameSite || false,
       };
 
       const authHandler =

--- a/packages/ldap-auth-backend/src/types.ts
+++ b/packages/ldap-auth-backend/src/types.ts
@@ -114,6 +114,7 @@ import type { defaultCheckUserExists, defaultLDAPAuthentication } from "./ldap";
 export type CookiesOptions = {
   field: string;
   secure: boolean;
+  sameSite: boolean | "lax" | "strict" | "none";
 };
 
 export type BackstageLdapAuthConfiguration = {


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](https://github.com/immobiliare/backstage-plugin-ldap-auth/CONTRIBUTING.md) to this repository.

It would be useful to be able to configure the SameSite field of the authentication cookie for scenarios where the backend is being hosted on a different domain than the frontend. If this field is not set, most browsers default to 'lax', essentially blocking the cookie from working in this scenario

This PR simply exposes the option to be able to configure this field. I kept the default as false to replicate the existing behavior.

Please let me know if you have any suggestions and thank you for your time

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `sameSite` cookie attribute for LDAP authentication, supporting `false`, `true`, `"lax"`, `"strict"`, or `"none"`. Defaults to `false` for backward compatibility.

* **Documentation**
  * Updated LDAP auth cookie configuration example to demonstrate the new `sameSite` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->